### PR TITLE
💚 CI refactoring with regards to licensing

### DIFF
--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -150,11 +150,6 @@ stages:
 
           - template: steps/generate-spdx-documents.yml
 
-          - publish: $(temp_spdx_reports_path)
-            artifact: SPDX
-            displayName: 'Publish SPDX reports'
-            condition: always()
-
   # Collect test and build stages together before the release stages to provide a pass/fail point for the status badge.
   - stage: CiCheckpoint
     displayName: 'CI Checkpoint'

--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -153,6 +153,7 @@ stages:
           - publish: $(temp_spdx_reports_path)
             artifact: SPDX
             displayName: 'Publish SPDX reports'
+            condition: always()
 
   # Collect test and build stages together before the release stages to provide a pass/fail point for the status badge.
   - stage: CiCheckpoint

--- a/azure-pipelines/steps/generate-spdx-documents.yml
+++ b/azure-pipelines/steps/generate-spdx-documents.yml
@@ -11,3 +11,8 @@ steps:
   - script: |
       license-files
     displayName: 'Add copyright/licence notice.'
+
+  - publish: $(temp_spdx_reports_path)
+    artifact: SPDX
+    displayName: 'Publish SPDX reports'
+    condition: always()

--- a/news/20200416.misc
+++ b/news/20200416.misc
@@ -1,0 +1,1 @@
+Refactored CI job to ensure licensing artifacts are uploaded no matter the result of the reporting.


### PR DESCRIPTION
### Description

Refactored the CI in order to ensure licensing reports are always uploaded.


### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
