### PR TITLE
assert-news: add `-u` command-line option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
   hooks:
     - id: assertnews
       name: news file
-      entry: assert-news -l
+      entry: assert-news -l -u
       language: python
       types: [file]
       require_serial: true

--- a/mbed_tools_ci_scripts/utils/git_helpers.py
+++ b/mbed_tools_ci_scripts/utils/git_helpers.py
@@ -526,6 +526,18 @@ class GitWrapper:
         is_release = self.is_release_branch(current_branch)
         return not (is_master or is_beta or is_release)
 
+    def uncommitted_changes_as_str(self) -> List[str]:
+        """Gets list of uncommitted files.
+
+        Returns:
+             list of uncommitted
+        """
+        status = self.repo.git.status(porcelain=True, untracked_files=True)
+        if not status:
+            return []
+
+        return [line.strip().split(" ")[-1] for line in status.splitlines()]
+
     @property
     def uncommitted_changes(self) -> List[Path]:
         """Gets list of uncommitted files.

--- a/news/20200706.bugfix
+++ b/news/20200706.bugfix
@@ -1,0 +1,1 @@
+assert-news: add `-u` command-line option

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -20,6 +20,7 @@ class TestGitWrapper(TestCase):
         self.assertTrue("." in version)
         self.assertTrue(git.get_commit_count() > 0)
         self.assertIsNotNone(git.uncommitted_changes)
+        self.assertIsNotNone(git.uncommitted_changes_as_str())
         self.assertIsNotNone(git.get_remote_url())
 
 
@@ -61,10 +62,13 @@ class TestGitTempClone(TestCase):
             self.assertTrue(len(clone.list_files_added_on_current_branch()) == 0)
             previous_hash = clone.get_commit_hash()
             previous_count = clone.get_commit_count()
-            test_file = Path(clone.root).joinpath(f"branch-test-{uuid4()}.txt")
+            file_name = f"branch-test-{uuid4()}.txt"
+            test_file = Path(clone.root).joinpath(file_name)
             test_file.touch()
             uncommitted_changes = clone.uncommitted_changes
             self.assertTrue(test_file in uncommitted_changes)
+            uncommitted_changes_as_str = clone.uncommitted_changes_as_str()
+            self.assertTrue(file_name in uncommitted_changes_as_str)
             clone.add(test_file)
             clone.commit("Test commit")
             self.assertNotEqual(previous_hash, clone.get_commit_hash())
@@ -75,7 +79,8 @@ class TestGitTempClone(TestCase):
     def test_file_addition_with_paths_to_initial_repository(self):
         """Test basic git add on the clone."""
         git = ProjectGitWrapper()
-        test_file = Path(git.root).joinpath(f"a_test_file-{uuid4()}.txt")
+        file_name = f"a_test_file-{uuid4()}.txt"
+        test_file = Path(git.root).joinpath(file_name)
         test_file.touch()
         with GitTempClone(repository_to_clone=git, desired_branch_name="master") as clone:
             test_file.unlink()
@@ -83,6 +88,8 @@ class TestGitTempClone(TestCase):
             clone.checkout(branch)
             uncommitted_changes = clone.uncommitted_changes
             self.assertTrue(clone.get_corresponding_path(test_file) in uncommitted_changes)
+            uncommitted_changes_as_str = clone.uncommitted_changes_as_str()
+            self.assertTrue(file_name in uncommitted_changes_as_str)
             clone.add(test_file)
             clone.commit("Test commit")
             added_files = [Path(git.root).joinpath(f) for f in clone.list_files_added_on_current_branch()]


### PR DESCRIPTION

### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
assert-news ignores uncommitted changes when invoked with `-l` option.
But `-l` is the option used in `pre-commit` hook tests which is used
before a commit a created. This means that news files will be
uncommitted at this stage. This is causing `pre-commit` hook failures
when invoked locally.

The `.pre-commit-config.yaml` has been updated to add `-u` option

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
