### PR TITLE
license_files: Fix copyright

### DIFF
--- a/docs/create_news_file.html
+++ b/docs/create_news_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_docs.html
+++ b/docs/generate_docs.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/generate_news.html
+++ b/docs/generate_news.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/get_config.html
+++ b/docs/get_config.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/license_files.html
+++ b/docs/license_files.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/report_third_party_ip.html
+++ b/docs/report_third_party_ip.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/index.html
+++ b/docs/spdx_report/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_dependency.html
+++ b/docs/spdx_report/spdx_dependency.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_document.html
+++ b/docs/spdx_report/spdx_document.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_file.html
+++ b/docs/spdx_report/spdx_file.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_helpers.html
+++ b/docs/spdx_report/spdx_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_package.html
+++ b/docs/spdx_report/spdx_package.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_project.html
+++ b/docs/spdx_report/spdx_project.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/spdx_report/spdx_summary.html
+++ b/docs/spdx_report/spdx_summary.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/tag_and_release.html
+++ b/docs/tag_and_release.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/third_party_IP_report.html
+++ b/docs/third_party_IP_report.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/aws_helpers.html
+++ b/docs/utils/aws_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/configuration.html
+++ b/docs/utils/configuration.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/definitions.html
+++ b/docs/utils/definitions.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/filesystem_helpers.html
+++ b/docs/utils/filesystem_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/git_helpers.html
+++ b/docs/utils/git_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/hash_helpers.html
+++ b/docs/utils/hash_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/index.html
+++ b/docs/utils/index.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/logging.html
+++ b/docs/utils/logging.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/package_helpers.html
+++ b/docs/utils/package_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/python_helpers.html
+++ b/docs/utils/python_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/string_helpers.html
+++ b/docs/utils/string_helpers.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/docs/utils/third_party_licences.html
+++ b/docs/utils/third_party_licences.html
@@ -1,5 +1,5 @@
 <!--
--- Copyright (C) 2020 Arm Mbed. All rights reserved.
+-- Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 -->
 <!doctype html>

--- a/mbed_tools_ci_scripts/__init__.py
+++ b/mbed_tools_ci_scripts/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Scripts and utilities used by the CI pipeline."""

--- a/mbed_tools_ci_scripts/_version.py
+++ b/mbed_tools_ci_scripts/_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """The version number is based on semantic versioning.

--- a/mbed_tools_ci_scripts/create_news_file.py
+++ b/mbed_tools_ci_scripts/create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Easy news files generation.

--- a/mbed_tools_ci_scripts/generate_docs.py
+++ b/mbed_tools_ci_scripts/generate_docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Generates documentation using Pdoc."""

--- a/mbed_tools_ci_scripts/generate_news.py
+++ b/mbed_tools_ci_scripts/generate_news.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Handles usage of towncrier for automated changelog generation and pyautoversion for versioning."""

--- a/mbed_tools_ci_scripts/get_config.py
+++ b/mbed_tools_ci_scripts/get_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Retrieves configuration values."""

--- a/mbed_tools_ci_scripts/license_files.py
+++ b/mbed_tools_ci_scripts/license_files.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-LICENCE_HEADER_TEMPLATE = """Copyright (C) {date} {author}. All rights reserved.
+LICENCE_HEADER_TEMPLATE = """Copyright (c) {date} {author} and Contributors. All rights reserved.
 SPDX-License-Identifier: {licence_identifier}
 """
 

--- a/mbed_tools_ci_scripts/license_files.py
+++ b/mbed_tools_ci_scripts/license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Apply copyright and licensing to all source files present in a project.

--- a/mbed_tools_ci_scripts/report_third_party_ip.py
+++ b/mbed_tools_ci_scripts/report_third_party_ip.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Script providing information about licensing and third party IP in order to comply with OpenChain.

--- a/mbed_tools_ci_scripts/spdx_report/__init__.py
+++ b/mbed_tools_ci_scripts/spdx_report/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Module in charge of handling SPDX documents.

--- a/mbed_tools_ci_scripts/spdx_report/spdx_dependency.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_dependency.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of dependency SPDX Document."""

--- a/mbed_tools_ci_scripts/spdx_report/spdx_document.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_document.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Document."""

--- a/mbed_tools_ci_scripts/spdx_report/spdx_file.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX File."""

--- a/mbed_tools_ci_scripts/spdx_report/spdx_helpers.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Facilities regarding SPDX.

--- a/mbed_tools_ci_scripts/spdx_report/spdx_package.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_package.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX Package."""

--- a/mbed_tools_ci_scripts/spdx_report/spdx_project.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition of an SPDX report for a Python project."""

--- a/mbed_tools_ci_scripts/spdx_report/spdx_summary.py
+++ b/mbed_tools_ci_scripts/spdx_report/spdx_summary.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Summary generators."""

--- a/mbed_tools_ci_scripts/tag_and_release.py
+++ b/mbed_tools_ci_scripts/tag_and_release.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Orchestrates release process."""

--- a/mbed_tools_ci_scripts/utils/__init__.py
+++ b/mbed_tools_ci_scripts/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility scripts to abstract and assist with scripts run in the CI."""

--- a/mbed_tools_ci_scripts/utils/aws_helpers.py
+++ b/mbed_tools_ci_scripts/utils/aws_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for interacting with AWS services such as S3.

--- a/mbed_tools_ci_scripts/utils/configuration.py
+++ b/mbed_tools_ci_scripts/utils/configuration.py
@@ -144,7 +144,7 @@ class StaticConfig(GenericConfig):
     LOGGER_FORMAT = "%(levelname)s: %(message)s"
     BOT_USERNAME = "Monty Bot"
     BOT_EMAIL = "monty-bot@arm.com"
-    ORGANISATION = "Arm Mbed"
+    ORGANISATION = "Arm Limited"
     ORGANISATION_EMAIL = "support@mbed.com"
     FILE_LICENCE_IDENTIFIER = "Apache-2.0"
     COPYRIGHT_START_DATE = 2020

--- a/mbed_tools_ci_scripts/utils/configuration.py
+++ b/mbed_tools_ci_scripts/utils/configuration.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities in charge of fetching configuration values for the ci scripts."""

--- a/mbed_tools_ci_scripts/utils/definitions.py
+++ b/mbed_tools_ci_scripts/utils/definitions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Place to store generic project concepts for the ci scripts."""

--- a/mbed_tools_ci_scripts/utils/filesystem_helpers.py
+++ b/mbed_tools_ci_scripts/utils/filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers with regards to actions on the filesystem."""

--- a/mbed_tools_ci_scripts/utils/git_helpers.py
+++ b/mbed_tools_ci_scripts/utils/git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utility script to abstract git operations for our CI scripts."""

--- a/mbed_tools_ci_scripts/utils/hash_helpers.py
+++ b/mbed_tools_ci_scripts/utils/hash_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for calculating hashes or UUID."""

--- a/mbed_tools_ci_scripts/utils/logging.py
+++ b/mbed_tools_ci_scripts/utils/logging.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Helpers for logging errors according to severity of the exception."""

--- a/mbed_tools_ci_scripts/utils/package_helpers.py
+++ b/mbed_tools_ci_scripts/utils/package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities for retrieving Python's package information."""

--- a/mbed_tools_ci_scripts/utils/python_helpers.py
+++ b/mbed_tools_ci_scripts/utils/python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities around python language."""

--- a/mbed_tools_ci_scripts/utils/string_helpers.py
+++ b/mbed_tools_ci_scripts/utils/string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities regarding string handling."""

--- a/mbed_tools_ci_scripts/utils/third_party_licences.py
+++ b/mbed_tools_ci_scripts/utils/third_party_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Third party licences."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 [ProjectConfig]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Package definition for PyPI."""

--- a/tests/filesystem/test_filesystem_helpers.py
+++ b/tests/filesystem/test_filesystem_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import os

--- a/tests/generate_docs/test_generate_docs.py
+++ b/tests/generate_docs/test_generate_docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib

--- a/tests/git_helper/test_git_helpers.py
+++ b/tests/git_helper/test_git_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/hash/test_hash_generation.py
+++ b/tests/hash/test_hash_generation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/licensing/test_license_files.py
+++ b/tests/licensing/test_license_files.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from mbed_tools_ci_scripts.license_files import _to_copyright_date_string

--- a/tests/licensing/test_opensource_licences.py
+++ b/tests/licensing/test_opensource_licences.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/packaging/test_package_helpers.py
+++ b/tests/packaging/test_package_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/python_helpers/test_python_helpers.py
+++ b/tests/python_helpers/test_python_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from mbed_tools_ci_scripts.utils.python_helpers import flatten_dictionary

--- a/tests/spdx/test_spdx_file.py
+++ b/tests/spdx/test_spdx_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_helper.py
+++ b/tests/spdx/test_spdx_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/spdx/test_spdx_project.py
+++ b/tests/spdx/test_spdx_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase

--- a/tests/string_helpers/test_string_helpers.py
+++ b/tests/string_helpers/test_string_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest

--- a/tests/tag_and_release/test_update_documentation.py
+++ b/tests/tag_and_release/test_update_documentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for mbed_tools_ci_scripts.tag_and_release documentation update functions."""

--- a/tests/test_create_news_file.py
+++ b/tests/test_create_news_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import pathlib


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
The copyright notice was specifying 'Arm Mbed' as the owner. This is
incorrect, it should read 'Arm Limited and Contributors'. This PR
updates the licence template to use the correct copyright notice.

This PR also updates the copyright notices on all source files so we're
compliant with Arm's licensing requirements.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
